### PR TITLE
Update wmsLayer.ts

### DIFF
--- a/src/layer/wmsLayer.ts
+++ b/src/layer/wmsLayer.ts
@@ -27,6 +27,7 @@ export type WMSImplementationOptions = RasterLayerImplementationOptions & {
   tileSize: Size;
   version: string;
   singleImage2d: boolean;
+  headers?: Record>string, string>;
 };
 
 export type WMSOptions = RasterLayerOptions & {
@@ -206,6 +207,7 @@ class WMSLayer extends RasterLayer<WmsCesiumImpl | WmsOpenlayersImpl> {
       highResolution: this.highResolution,
       tileSize: this.tileSize,
       singleImage2d: this.singleImage2d,
+      headers: this.headers,
     };
   }
 


### PR DESCRIPTION
bei wms dienst mit basic authentication wird der konfigurierte authorization header nur bei getcapabilities mitgesendet. bei Getmap und GetLegendGraphic anfragen wird er nicht mitgeschickt